### PR TITLE
C1_W3_Lab_2_exploring_convolutions : syntax error

### DIFF
--- a/C1/W3/ungraded_labs/C1_W3_Lab_2_exploring_convolutions.ipynb
+++ b/C1/W3/ungraded_labs/C1_W3_Lab_2_exploring_convolutions.ipynb
@@ -157,7 +157,7 @@
         "      convolution = 0.0\n",
         "      convolution = convolution + (i[x-1, y-1] * filter[0][0])\n",
         "      convolution = convolution + (i[x-1, y] * filter[0][1])  \n",
-        "      convolution = convolution + (i[x-1. y+1] * filter[0][2])     \n",
+        "      convolution = convolution + (i[x-1, y+1] * filter[0][2])     \n",
         "      convolution = convolution + (i[x, y-1] * filter[1][0])    \n",
         "      convolution = convolution + (i[x, y] * filter[1][1])    \n",
         "      convolution = convolution + (i[x, y+1] * filter[1][2])    \n",


### PR DESCRIPTION
Corrected the syntax error from the notebook.
The issue was in accessing the image in the convolution step, where " . "(dot) was used instead of " , "(comma) resulting in the syntax error.