### PR TITLE
Update C3_W4_Lab_2_irish_lyrics.ipynb

### DIFF
--- a/C3/W4/ungraded_labs/C3_W4_Lab_2_irish_lyrics.ipynb
+++ b/C3/W4/ungraded_labs/C3_W4_Lab_2_irish_lyrics.ipynb
@@ -270,7 +270,8 @@
         "for _ in range(next_words):\n",
         "\ttoken_list = tokenizer.texts_to_sequences([seed_text])[0]\n",
         "\ttoken_list = pad_sequences([token_list], maxlen=max_sequence_len-1, padding='pre')\n",
-        "\tpredicted = model.predict_classes(token_list, verbose=0)\n",
+        "\tpredicted = model.predict(token_list, verbose=0)\n",
+        "\tpredicted = np.argmax(predicted, axis = 1)\n"
         "\toutput_word = \"\"\n",
         "\tfor word, index in tokenizer.word_index.items():\n",
         "\t\tif index == predicted:\n",


### PR DESCRIPTION
"predict_classes" is deprecated after version 2.6 of tensorflow, the lab uses tensorflow version 2.8 but still calling "predict_classes" function
The right way is to call "predict" function and pass the returned value from it to "numpy.argmax" function.