### PR TITLE
Get learning rate per epoch from model history

### DIFF
--- a/C4/W3/ungraded_labs/C4_W3_Lab_1_RNN.ipynb
+++ b/C4/W3/ungraded_labs/C4_W3_Lab_1_RNN.ipynb
@@ -422,7 +422,7 @@
    "outputs": [],
    "source": [
     "# Define the learning rate array\n",
-    "lrs = 1e-8 * (10 ** (np.arange(100) / 20))\n",
+    "lrs = history.history['lr']\n",
     "\n",
     "# Set the figure size\n",
     "plt.figure(figsize=(10, 6))\n",


### PR DESCRIPTION
The learning rate per epoch is provided by the keras model fit history. Instead of creating the learning rate using numpy arange, we can get it from the history dictionary which seems a neater way to do that.