### PR TITLE
updated the lines responsible for loading ascent image

### DIFF
--- a/C1/W3/ungraded_labs/C1_W3_Lab_2_exploring_convolutions.ipynb
+++ b/C1/W3/ungraded_labs/C1_W3_Lab_2_exploring_convolutions.ipynb
@@ -38,10 +38,10 @@
    },
    "outputs": [],
    "source": [
-    "from scipy import misc\n",
+    "import scipy\n",
     "\n",
     "# load the ascent image\n",
-    "ascent_image = misc.ascent()"
+    "ascent_image = scipy.datasets.ascent()"
    ]
   },
   {


### PR DESCRIPTION
scipy.misc.ascent has been deprecated in SciPy v1.10.0; and will be completely removed in SciPy v1.12.0. Dataset methods have moved into the scipy.datasets module.